### PR TITLE
Fix `(wrong-type-argument stringp nil)` error when calling `vdir-helm-select-email`

### DIFF
--- a/vdirel.el
+++ b/vdirel.el
@@ -137,11 +137,9 @@ If REPOSITORY is absent or nil, use the function `vdirel--repository'."
 Each element in the list is a cons cell containing the vCard property name
 in the `car', and the value of that property in the `cdr'.  Parsing is done
 through `org-vcard-import-parse'."
-  (with-temp-buffer
-    (insert-file-contents filename)
     (cons
      (cons "VDIREL-FILENAME" filename)
-     (car (org-vcard-import-parse "buffer")))))
+     (car (org-vcard-import-parse "buffer" filename))))
 
 (defun vdirel--build-contacts (&optional repository)
   "Return a list of contacts in REPOSITORY.


### PR DESCRIPTION
In `vdirel--parse-file-to-contact`, passing the filename of the vcard file to the `org-vcard-import-parse` eliminates the need for a temporary buffer and avoids the error reported in issue https://github.com/DamienCassou/vdirel/issues/19.

Fixes https://github.com/DamienCassou/vdirel/issues/19