### PR TITLE
Update makel URL

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ makel.mk:
 		curl \
 		--fail --silent --show-error --insecure --location \
 		--retry 9 --retry-delay 9 \
-		-O https://gitlab.petton.fr/DamienCassou/makel/raw/v0.5.3/makel.mk; \
+		-O https://github.com/DamienCassou/makel/raw/v0.8.0/makel.mk; \
 	fi
 
 # Include makel.mk if present


### PR DESCRIPTION
Should `.travis.yml` file still exist? It seems the Travis pipeline status is broken in any case.